### PR TITLE
Fixing HTTP not found status response in ToolController

### DIFF
--- a/src/controllers/ToolController.ts
+++ b/src/controllers/ToolController.ts
@@ -53,7 +53,7 @@ class ToolController {
                     await tool.remove();
                     return response.status(204).json();
                 }else {
-                    return response.status(400).json({
+                    return response.status(404).json({
                         error: true,
                         message: 'tool not found'
                     });


### PR DESCRIPTION
You burro man

the programmer that wrote this line has made a big mistake by using 400 status code instead of 404, i'm fixing this

não precisa agradecer

kisses <3   